### PR TITLE
Add line to Runout Sensor to fix inverting sensor.

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -2144,8 +2144,8 @@ void process_commands()
       if(Stopped == false) {
 
         #ifdef FILAMENT_RUNOUT_SUPPORT
-            
-            if(READ(FR_SENS)){
+            bool FR_SENS_INV_CORRECTED=(READ(FR_SENS) != FR_SENS_INVERTING);
+            if(FR_SENS_INV_CORRECTED){
 
                         feedmultiplyBckp=feedmultiply;
                         float target[4];

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -730,7 +730,7 @@ void lcd_commands()
 			lcd_commands_step = 5;
 			#endif
 			#ifdef DEFAULT_PID_BED_TEMP
-			lcd_commands_step = lcd_commands_step+1
+			lcd_commands_step = lcd_commands_step+1;
 			#endif
 		}
 


### PR DESCRIPTION
Tested and working with false set on const bool FR_SENS_INVERTING with opto endstop.

Let me know if you have any questions mate.

Look forward to more of your good work.

Rob