### PR TITLE
Add Po attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lang/po/*.po text eol=crlf


### PR DESCRIPTION
As done for editorconfig, this similarly forces git to handle
po files consistently in DOS format.